### PR TITLE
core: refactor to use relative imports

### DIFF
--- a/core/domain_class.py
+++ b/core/domain_class.py
@@ -164,7 +164,7 @@ class Domain(GeoBase, NodeCache, PropLocker):
 
     def __call__(self, value, index=None):
 
-        from geonodes import nd
+        from . import nd
 
         if index is None:
             index = nd.index
@@ -200,7 +200,7 @@ class Domain(GeoBase, NodeCache, PropLocker):
         - ForEachElement zone
         """
 
-        from geonodes import ForEachElement
+        from . import ForEachElement
 
         return ForEachElement(geometry=self._geo, selection=self._sel, domain=self.DOMAIN_NAME, sockets=sockets, **kwargs)
 

--- a/core/geometry_class.py
+++ b/core/geometry_class.py
@@ -85,7 +85,7 @@ class GeoBase:
     @property
     def _sel(self):
 
-        from geonodes import nd
+        from . import nd
 
         selection = self._raw_sel
 

--- a/core/pyswitch.py
+++ b/core/pyswitch.py
@@ -40,7 +40,7 @@ class IfElse:
     """ Root class for If, Else and Elif
     """
     def __enter__(self):
-        from geonodes import Layout
+        from . import Layout
         self.layout = Layout(self.layout_name)
         return self.socket
 
@@ -189,7 +189,7 @@ class If(IfElse):
         - tip (str = "") : user tip (used in menu creation and in Layout names)
         """
 
-        from geonodes import Node
+        from . import Node
 
         self.socket_class = socket_class
         self.selector     = selector
@@ -243,7 +243,7 @@ class If(IfElse):
         - socket (Socket) : socket to plug in the current option
         """
 
-        from geonodes import Tree
+        from . import Tree
 
         if self.node_name == "Switch":
 

--- a/core/sock_float.py
+++ b/core/sock_float.py
@@ -346,13 +346,13 @@ class Float(generated.Float):
     # ----- Addition
 
     def __add__(self, other):
-        from geonodes import Vector
+        from . import Vector
         if utils.is_vector_like(other):
             return Vector(self).add(other)
         return self.add(other)
 
     def __radd__(self, other):
-        from geonodes import Vector
+        from . import Vector
         if utils.is_vector_like(other):
             return Vector(other).add(self)
         return self.add(other)
@@ -363,13 +363,13 @@ class Float(generated.Float):
     # ----- Subtraction
 
     def __sub__(self, other):
-        from geonodes import Vector
+        from . import Vector
         if utils.is_vector_like(other):
             return Vector(self).subtract(other)
         return self.subtract(other)
 
     def __rsub__(self, other):
-        from geonodes import Vector
+        from . import Vector
         if utils.is_vector_like(other):
             return Vector(other).subtract(self)
         return Float(other).subtract(self)
@@ -380,13 +380,13 @@ class Float(generated.Float):
     # ----- Multiplication
 
     def __mul__(self, other):
-        from geonodes import Vector
+        from . import Vector
         if utils.is_vector_like(other):
             return Vector(other).scale(self)
         return self.multiply(other)
 
     def __rmul__(self, other):
-        from geonodes import Vector
+        from . import Vector
         if utils.is_vector_like(other):
             return Vector(other).scale(self)
         return self.multiply(other)
@@ -397,13 +397,13 @@ class Float(generated.Float):
     # ----- Division
 
     def __truediv__(self, other):
-        from geonodes import Vector
+        from . import Vector
         if utils.is_vector_like(other):
             return Vector(other).divide(self)
         return self.divide(other)
 
     def __rtruediv__(self, other):
-        from geonodes import Vector
+        from . import Vector
         if utils.is_vector_like(other):
             return Vector(self).divide(other)
         return Float(other).divide(self)
@@ -414,13 +414,13 @@ class Float(generated.Float):
     # ----- Modulo
 
     def __mod__(self, other):
-        from geonodes import Vector
+        from . import Vector
         if utils.is_vector_like(other):
             return Vector(self).modulo(other)
         return self.modulo(other)
 
     def __rmod__(self, other):
-        from geonodes import Vector
+        from . import Vector
         if utils.is_vector_like(other):
             return Vector(other).modulo(self)
         return Float(other).modulo(self)

--- a/core/sock_integer.py
+++ b/core/sock_integer.py
@@ -225,7 +225,7 @@ class Integer(generated.Integer):
     # ----- Addition
 
     def __add__(self, other):
-        from geonodes import gnmath
+        from . import gnmath
         if utils.is_vector_like(other):
             return gnmath.vadd(self, other)
         elif utils.is_int_like(other):
@@ -234,7 +234,7 @@ class Integer(generated.Integer):
             return gnmath.add(self, other)
 
     def __radd__(self, other):
-        from geonodes import gnmath
+        from . import gnmath
         if utils.is_vector_like(other):
             return gnmath.vadd(other, self)
         elif utils.is_int_like(other):
@@ -248,7 +248,7 @@ class Integer(generated.Integer):
     # ----- Subtraction
 
     def __sub__(self, other):
-        from geonodes import gnmath
+        from . import gnmath
         if utils.is_vector_like(other):
             return gnmath.vsubtract(self, other)
         elif utils.is_int_like(other):
@@ -257,7 +257,7 @@ class Integer(generated.Integer):
             return gnmath.subtract(self, other)
 
     def __rsub__(self, other):
-        from geonodes import gnmath
+        from . import gnmath
         if utils.is_vector_like(other):
             return gnmath.vsubtract(other, self)
         elif utils.is_int_like(other):
@@ -271,7 +271,7 @@ class Integer(generated.Integer):
     # ----- Multiplication
 
     def __mul__(self, other):
-        from geonodes import gnmath
+        from . import gnmath
         if utils.is_vector_like(other):
             return gnmath.scale(other, self)
         elif utils.is_int_like(other):
@@ -280,7 +280,7 @@ class Integer(generated.Integer):
             return gnmath.multiply(self, other)
 
     def __rmul__(self, other):
-        from geonodes import gnmath
+        from . import gnmath
         if utils.is_vector_like(other):
             return gnmath.scale(other, self)
         elif utils.is_int_like(other):
@@ -316,14 +316,14 @@ class Integer(generated.Integer):
     # ----- Power
 
     def __pow__(self, other):
-        from geonodes import gnmath
+        from . import gnmath
         if utils.is_int_like(other):
             return self.power(other)
         else:
             return gnmath.power(self, other)
 
     def __rpow__(self, other):
-        from geonodes import gnmath
+        from . import gnmath
         if utils.is_int_like(other):
             return Integer(other).power(self)
         else:
@@ -335,15 +335,15 @@ class Integer(generated.Integer):
     # ----- Division
 
     def __truediv__(self, other):
-        from geonodes import Float
+        from . import Float
         return Float(self)/other
 
     def __rtruediv__(self, other):
-        from geonodes import Float
+        from . import Float
         return other/Float(self)
 
     def __itruediv__(self, other):
-        from geonodes import Float
+        from . import Float
         return Integer(Float(self)/other)
 
     # =============================================================================================================================

--- a/core/sock_rotation.py
+++ b/core/sock_rotation.py
@@ -87,7 +87,7 @@ class Rotation(generated.Rotation):
         - hide_in_modifier (bool = False) : Hide in Modifier option
         - single_value (bool = False) : Single Value option
         """
-        from geonodes import Vector
+        from . import Vector
 
         if isinstance(value, str):
             value = type(self).Named(value)

--- a/core/socket_class.py
+++ b/core/socket_class.py
@@ -404,7 +404,7 @@ class Socket(NodeCache, PropLocker):
             return socket_class[socket_type]
 
         elif Tree.is_shader:
-            from geonodes import Float, Vector, Color, String, Shader
+            from . import Float, Vector, Color, String, Shader
 
             socket_class = {
                 'VALUE': Float, 'VECTOR': Vector, 'RGBA': Color,
@@ -1035,11 +1035,11 @@ class Socket(NodeCache, PropLocker):
     @classmethod
     def _run_tests(cls):
 
-        from geonodes import GeoNodes
+        from . import GeoNodes
 
         import inspect
         import re
-        from geonodes.core import constants
+        from . import constants
 
         tree = None
 

--- a/core/treearrange.py
+++ b/core/treearrange.py
@@ -1448,7 +1448,7 @@ class NodeDumpOperator(bpy.types.Operator):
 
     def execute(self, context):
 
-        from geonodes.generation.node_explore import NodeInfo
+        from ..generation.node_explore import NodeInfo
 
         space = context.space_data
         tree = space.edit_tree

--- a/core/treeclass.py
+++ b/core/treeclass.py
@@ -1173,7 +1173,7 @@ class Tree:
     @staticmethod
     def get_data_socket_class(socket_type):
 
-        from geonodes.core import Boolean, Integer, Float, Vector, Rotation, Matrix, Color, Geometry, Material, Image, Object, Collection, String, Menu
+        from . import Boolean, Integer, Float, Vector, Rotation, Matrix, Color, Geometry, Material, Image, Object, Collection, String, Menu
 
         socket_class = {'BOOLEAN': Boolean, 'INT': Integer, 'VALUE': Float, 'VECTOR': Vector, 'ROTATION': Rotation, 'MATRIX': Matrix, 'RGBA': Color,
             'STRING': String, 'MENU': Menu,
@@ -1562,8 +1562,8 @@ class Node:
         else:
             class_name = constants.CLASS_NAMES[socket_type]
 
-        exec(f"from geonodes import {class_name}", locals(), globals())
-        return eval(f"{class_name}(bsocket)", locals(), globals())
+        mod = __import__('', globals(), locals(), [class_name], 2)
+        return getattr(mod, class_name)(bsocket)
 
     # ----------------------------------------------------------------------------------------------------
     # Set the node parameters

--- a/core/zones.py
+++ b/core/zones.py
@@ -134,7 +134,7 @@ class Zone:
     TEMP_ZONE    = True
 
     def init_layout(self):
-        from geonodes import Layout
+        from . import Layout
         if Zone.TEMP_ZONE:
             self._layout = Layout("$TEMP_ZONE")
         else:


### PR DESCRIPTION
Blender extension policy disallows modifying sys.path. While extensions allow including python modules packaged as whl, using whl's can be quite akward as they require more complicated build time infrastructure, and even then geonodes would have to provide setup.py to support that.

Simplest way to support using geonodes in extensions is to use relative imports which allows using geonodes as a git submodule, or simply copying into a project.